### PR TITLE
feat: add new bundle hooks and improve build options

### DIFF
--- a/src/bin/build.ts
+++ b/src/bin/build.ts
@@ -31,7 +31,7 @@ export async function build(
     files: [],
   }
 
-  if (hooks?.['build:before']) await hooks['build:before'](options)
+  if (hooks?.['build:start']) await hooks['build:start'](options, buildStats)
 
   if (options.entries) {
     start = Date.now()
@@ -143,7 +143,7 @@ export async function build(
     buildStats.buildTime = Date.now() - start
   }
 
-  if (hooks?.['build:done']) await hooks['build:done'](options)
+  if (hooks?.['build:end']) await hooks['build:end'](options, buildStats)
 
   return buildStats
 }


### PR DESCRIPTION

## Type of Change

- [x] New feature


## Request Description

Adds new `bundle` hooks and improves `build` options.

```ts
// bundler.config.ts

import { defineConfig } from '@hypernym/bundler'

export default defineConfig({
  hooks: {
    // called right after building is complete.
    'build:end': async (options, buildStats) => {
      const start = Date.now()

      // here you can add some code to create custom new files etc...
      await writeFile('./dist/my-file.mjs')
      // ...

      // and after that you can push the results to `buildStats` to be logged with other module stats
      buildStats.files.push({
        path: './dist/my-file.mjs',
        size: 33,
        buildTime: Date.now() - start,
        format: 'esm',
        logs: [], // warnings
      })
    },

    // called right after bundling is complete.
    'bundle:end': async (options, buildStats) => {
      // or you can skip the build mode and add the code after the bundling is complete
      await writeFile('./dist/my-file.mjs')

      // this will be logged separately, after `buildStats`
      console.log('...')

      // ...
    },
  },
})
```
