### PR TITLE
feat: add new hook

### DIFF
--- a/src/types/entries.ts
+++ b/src/types/entries.ts
@@ -1,7 +1,7 @@
 import type { OutputOptions } from 'rollup'
 import type { BuildPlugins } from './plugins.js'
 
-export interface Entry {
+export interface EntryBase {
   /**
    * Specifies the path of the transformed module.
    *
@@ -45,7 +45,7 @@ export interface Entry {
   logFilter?: string[]
 }
 
-export interface EntryInput extends Entry {
+export interface EntryInput extends EntryBase {
   /**
    * Specifies the path of the module's build source.
    */
@@ -58,7 +58,7 @@ export interface EntryInput extends Entry {
   plugins?: BuildPlugins
 }
 
-export interface EntryTypes extends Entry {
+export interface EntryTypes extends EntryBase {
   /**
    * Specifies the path of the module's build source that contains only TS definitions.
    */
@@ -71,4 +71,4 @@ export interface EntryTypes extends Entry {
   plugins?: Pick<BuildPlugins, 'dts'>
 }
 
-export type EntriesOptions = EntryInput | EntryTypes
+export type EntryOptions = EntryInput | EntryTypes

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,5 +1,7 @@
+import type { Plugin } from 'rollup'
 import type { Options } from './options.js'
 import type { BuildStats } from './build.js'
+import type { EntryInput, EntryTypes } from './entries.js'
 
 export interface HooksOptions {
   /**
@@ -16,6 +18,8 @@ export interface HooksOptions {
    *   }
    * })
    * ```
+   *
+   * @default undefined
    */
   'bundle:start'?: (options?: Options) => void | Promise<void>
   /**
@@ -32,11 +36,47 @@ export interface HooksOptions {
    *   }
    * })
    * ```
+   *
+   * @default undefined
    */
   'build:start'?: (
     options?: Options,
     buildStats?: BuildStats,
   ) => void | Promise<void>
+  /**
+   * Called just before the initialization of the Rollup plugin.
+   *
+   * Provides the ability to add and manipulate custom plugins.
+   *
+   * @example
+   *
+   * ```ts
+   * import { plugin1, plugin2, plugin3 } from './plugins'
+   *
+   * export default defineConfig({
+   *   hooks: {
+   *     'rollup:plugins': (plugins, entry) => {
+   *       // adds a custom plugin before the default bundler plugins
+   *       plugins.unshift(plugin1())
+   *       // adds a custom plugin after the default bundler plugins
+   *       plugins.push(plugin2())
+   *       // adds a custom plugin for a specific entry only
+   *       if (entry?.input?.includes('./src/index.ts')) {
+   *         plugins.push(plugin3())
+   *       }
+   *       // returns the final list of plugins
+   *       return plugins
+   *     }
+   *   }
+   * })
+   * ```
+   *
+   * @default undefined
+   */
+  'rollup:plugins'?: (
+    plugins: Plugin[],
+    entry?: Partial<EntryInput> & Partial<Omit<EntryTypes, 'plugins'>>,
+  ) => Plugin[]
   /**
    * Called right after building is complete.
    *
@@ -51,6 +91,8 @@ export interface HooksOptions {
    *   }
    * })
    * ```
+   *
+   * @default undefined
    */
   'build:end'?: (
     options?: Options,
@@ -70,6 +112,8 @@ export interface HooksOptions {
    *   }
    * })
    * ```
+   *
+   * @default undefined
    */
   'bundle:end'?: (options?: Options) => void | Promise<void>
 }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import type { EntriesOptions } from './entries.js'
+import type { EntryOptions } from './entries.js'
 import type { HooksOptions } from './hooks.js'
 
 export interface Options {
@@ -19,7 +19,7 @@ export interface Options {
    * })
    * ```
    */
-  entries: EntriesOptions[]
+  entries: EntryOptions[]
   /**
    * Specifies the output directory for production bundle.
    *


### PR DESCRIPTION

## Type of Change

- [x] New feature

## Request Description

Adds new `rollup:plugins` hook.

### rollup:plugins

Called just before the initialization of the Rollup plugin.

Provides the ability to add and manipulate custom plugins.

```ts
// bundler.config.ts

import { defineConfig } from '@hypernym/bundler'
import { plugin1, plugin2, plugin3 } from './src/utils/plugins.js'

export default defineConfig({
  hooks: {
    'rollup:plugins': (plugins, entry) => {
      // adds a custom plugin before the default bundler plugins
      plugins.unshift(plugin1())

      // adds a custom plugin after the default bundler plugins
      plugins.push(plugin2())

      // adds a custom plugin for a specific entry only
      if (entry?.input?.includes('./src/index.ts')) {
        plugins.push(plugin3())
      }

      // returns the final list of plugins
      return plugins
    },
  },
})
```
