### PR TITLE
feat: extend entry options

### DIFF
--- a/src/bin/build.ts
+++ b/src/bin/build.ts
@@ -56,6 +56,12 @@ export async function build(
           pluginsOptions: typeof entry.plugins
           banner: typeof entry.banner
           footer: typeof entry.footer
+          intro: typeof entry.intro
+          outro: typeof entry.outro
+          paths: typeof entry.paths
+          name: typeof entry.name
+          globals: typeof entry.globals
+          extend: typeof entry.extend
         } = {
           input: entry.input,
           output: entry.output || _output,
@@ -65,6 +71,12 @@ export async function build(
           pluginsOptions: entry.plugins,
           banner: entry.banner,
           footer: entry.footer,
+          intro: entry.intro,
+          outro: entry.outro,
+          paths: entry.paths,
+          name: entry.name,
+          globals: entry.globals,
+          extend: entry.extend,
         }
 
         if (_entry.pluginsOptions?.json) {
@@ -106,6 +118,12 @@ export async function build(
           format: _entry.format,
           banner: _entry.banner,
           footer: _entry.footer,
+          intro: _entry.intro,
+          outro: _entry.outro,
+          paths: _entry.paths,
+          name: _entry.name,
+          globals: _entry.globals,
+          extend: _entry.extend,
         })
         const stats = await stat(resolve(cwd, _entry.output))
 
@@ -138,6 +156,9 @@ export async function build(
           pluginsOptions: typeof entry.plugins
           banner: typeof entry.banner
           footer: typeof entry.footer
+          intro: typeof entry.intro
+          outro: typeof entry.outro
+          paths: typeof entry.paths
         } = {
           types: entry.types,
           output: entry.output || _output,
@@ -147,6 +168,9 @@ export async function build(
           pluginsOptions: entry.plugins,
           banner: entry.banner,
           footer: entry.footer,
+          intro: entry.intro,
+          outro: entry.outro,
+          paths: entry.paths,
         }
 
         if (hooks?.['build:entry:start']) {
@@ -166,6 +190,9 @@ export async function build(
           format: _entry.format,
           banner: _entry.banner,
           footer: _entry.footer,
+          intro: _entry.intro,
+          outro: _entry.outro,
+          paths: _entry.paths,
         })
         const stats = await stat(resolve(cwd, _entry.output))
 

--- a/src/types/entries.ts
+++ b/src/types/entries.ts
@@ -38,6 +38,24 @@ export interface EntryBase {
    */
   footer?: OutputOptions['footer']
   /**
+   * Specifies the code at the beginning that goes inside any _format-specific_ wrapper.
+   *
+   * @default undefined
+   */
+  intro?: OutputOptions['intro']
+  /**
+   * Specifies the code at the end that goes inside any _format-specific_ wrapper.
+   *
+   * @default undefined
+   */
+  outro?: OutputOptions['outro']
+  /**
+   * Maps external module IDs to paths.
+   *
+   * @default undefined
+   */
+  paths?: OutputOptions['paths']
+  /**
    * Specifies custom filters that will display only certain log messages.
    *
    * @default undefined
@@ -56,6 +74,28 @@ export interface EntryInput extends EntryBase {
    * @default undefined
    */
   plugins?: PluginsInput
+  /**
+   * Specifies the global variable name that representing exported bundle.
+   *
+   * Intended for `umd/iife` formats.
+   *
+   * @default undefined
+   */
+  name?: OutputOptions['name']
+  /**
+   * Specifies global _module ID_ and _variable name_ pairs necessary for external imports.
+   *
+   * Intended for `umd/iife` formats.
+   *
+   * @default undefined
+   */
+  globals?: OutputOptions['globals']
+  /**
+   * Specifies whether to extend the global variable defined by the `name` option.
+   *
+   * Intended for `umd/iife` formats.
+   */
+  extend?: OutputOptions['extend']
 }
 
 export interface EntryTypes extends EntryBase {


### PR DESCRIPTION

## Type of Change


- [x] New feature

## Request Description

Extends `entry` options.

New options:

- `entry.intro` - Specifies the code at the beginning that goes inside any _format-specific_ wrapper.
- `entry.outro` - Specifies the code at the end that goes inside any _format-specific_ wrapper.
- `entry.paths` - Maps external module IDs to paths.
- `entry.name` - Specifies the global variable name that representing exported bundle.
- `entry.globals` - Specifies global _module ID_ and _variable name_ pairs necessary for external imports.
- `entry.extend` - Specifies whether to extend the global variable defined by the `name` option.