### PR TITLE
feat: add new alias option

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,28 @@ export default defineConfig({
 })
 ```
 
+### alias
+
+- Type: `true`
+- Default: `undefined`
+
+Specifies global path alias support.
+
+If true, it enables import prefixes:
+
+- `@/*`
+- `~/*`
+
+```ts
+// Imports module from './src/utils/index.js'
+import { module } from '@/utils/index.js'
+
+// or
+
+// Imports module from './src/utils/index.js'
+import { module } from '~/utils/index.js'
+```
+
 ## CLI
 
 ### Custom Config
@@ -271,11 +293,13 @@ npx hyperbundler --config my.config.js
 
 ## Community
 
-Feel free to use the official [discussions](https://github.com/hypernym-studio/bundler/discussions) for any additional questions.
+Feel free to ask questions or share new ideas.
+
+Use the official [discussions](https://github.com/hypernym-studio/bundler/discussions) to get involved.
 
 ## License
 
-Developed in 🇭🇷 Croatia
+Developed in 🇭🇷 Croatia.
 
 Released under the [MIT](LICENSE.txt) license.
 

--- a/bundler.config.ts
+++ b/bundler.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from './src/config.js'
 import { name, version } from './package.json'
 
 export default defineConfig({
+  alias: true,
   entries: [
     { input: './src/index.ts' },
     { types: './src/types/index.ts' },

--- a/src/bin/builder.ts
+++ b/src/bin/builder.ts
@@ -4,9 +4,9 @@ import { green, cyan, magenta, red, dim } from '@hypernym/colors'
 import { createSpinner } from '@hypernym/spinner'
 import { version } from './meta.js'
 import { build } from './build.js'
-import { cl, logger, formatMs, formatBytes } from '../utils/index.js'
-import type { Options } from '../types/options.js'
-import type { Args } from '../types/args.js'
+import { cl, logger, formatMs, formatBytes } from '@/utils/index.js'
+import type { Options } from '@/types/options.js'
+import type { Args } from '@/types/args.js'
 
 export async function createBuilder(cwd: string, args: Args, options: Options) {
   const { hooks } = options

--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -4,8 +4,8 @@ import { cwd as _cwd } from 'node:process'
 import { createArgs } from '@hypernym/args'
 import { createConfigLoader } from './loader.js'
 import { createBuilder } from './builder.js'
-import { error } from '../utils/index.js'
-import type { Args } from '../types/args.js'
+import { error } from '@/utils/index.js'
+import type { Args } from '@/types/args.js'
 
 async function main() {
   const cwd = _cwd()

--- a/src/bin/loader.ts
+++ b/src/bin/loader.ts
@@ -4,9 +4,9 @@ import { exists, writeFile } from '@hypernym/utils/fs'
 import { cyan } from '@hypernym/colors'
 import { build } from 'esbuild'
 import { externals } from '../config.js'
-import { logger, error } from '../utils/index.js'
-import type { Options } from '../types/options.js'
-import type { Args } from '../types/args.js'
+import { logger, error } from '@/utils/index.js'
+import type { Options } from '@/types/options.js'
+import type { Args } from '@/types/args.js'
 
 export async function loadConfig(
   cwd: string,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import type { Options } from './types/options.js'
+import type { Options } from '@/types/options.js'
 
 /**
  * List of global defaults for externals.

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -55,4 +55,22 @@ export interface Options {
    * @default undefined
    */
   hooks?: HooksOptions
+  /**
+   * Specifies global path alias support.
+   *
+   * If true, it enables import prefixes:
+   *
+   * - `@/*`
+   * - `~/*`
+   *
+   * @example
+   *
+   * ```ts
+   * // Imports module from './src/utils/index.js'
+   * import { module } from '@/utils/index.js'
+   * ```
+   *
+   * @default undefined
+   */
+  alias?: true
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { logger } from '../utils/logger.js'
+import { logger } from '@/utils/logger.js'
 
 export function error(err: any): never {
   logger.error('Something went wrong...')

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,6 @@
 import process from 'node:process'
 import { cyan, magenta, red, dim } from '@hypernym/colors'
-import { name, version } from '../bin/meta.js'
+import { name, version } from '@/bin/meta.js'
 
 export const cl = console.log
 


### PR DESCRIPTION

## Type of Change

- [x] New feature

## Request Description

Adds new `alias` option.

### alias

- Type: `true`
- Default: `undefined`

Specifies global path alias support.

If true, it enables import prefixes:

- `@/*`
- `~/*`

```ts
// Imports module from './src/utils/index.js'
import { module } from '@/utils/index.js'

// or

// Imports module from './src/utils/index.js'
import { module } from '~/utils/index.js'
```