### PR TITLE
feat: add new minify options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@
 
 1. Create a `bundler.config.ts` file at the root of your project:
 
-> [!NOTE]
->
-> Configuration also accepts `.js`, `.mjs`, `.ts`, `.mts` formats.
-
 ```ts
 // bundler.config.ts
 
@@ -66,9 +62,7 @@ export default defineConfig({
     {
       input: './src/utils/index.ts',
       output: './dist/utils/utils.min.mjs',
-      transformers: {
-        esbuild: { minify: true },
-      },
+      minify: true,
     },
     // ...
   ],
@@ -81,35 +75,33 @@ export default defineConfig({
 npx hyperbundler
 ```
 
-<details>
-<summary>CLI Output</summary>
+## Config
 
-<br>
-<p>Example of CLI Output:</p>
+`Hyperbundler` automatically detects custom configuration from the project root that can override or extend the build behavior.
 
-```txt
-┌─────────────────┐
-│ ✦✦ HYPERBUNDLER │ v0.11.0
-└─────────────────┘
-i Config bundler.config.ts
-i Bundling started...
-* Processing [8:07:26 PM] Transforming files
-│
-├─ + esm ./dist/index.mjs (50ms) 313 B
-├─ + dts ./dist/types/index.d.ts (1.23s) 13.61 KB
-├─ + esm ./dist/bin/index.mjs (119ms) 16.53 KB
-│
-* Succeeded [8:07:28 PM] Module transformation is done
-✔ Bundling fully completed in 1.40s
-✔ 3 modules transformed. Total size is 30.45 KB
-✦✦ HYPERBUNDLER [8:07:28 PM] Bundle is generated and ready for production
+Configuration file also accepts `.js`, `.mjs`, `.ts`, `.mts` formats.
+
+```ts
+// bundler.config.{js,mjs,ts,mts}
+
+import { defineConfig } from '@hypernym/bundler'
+
+export default defineConfig({
+  // ...
+})
 ```
 
-</details>
+### Custom path
+
+Set a custom config path via the CLI command:
+
+```sh
+npx hyperbundler --config hyper.config.ts
+```
 
 ## Options
 
-All options are documented with descriptions and examples, and auto-completion will be offered as you type.
+All options are documented with descriptions and examples so auto-completion will be offered as you type.
 
 Simply hover over the property and see what it does in the `quickinfo`.
 
@@ -294,6 +286,36 @@ Now imports can be used like this:
 import { module } from '#/utils' // #
 ```
 
+### minify
+
+- Type: `boolean`
+- Default: `undefined`
+
+Specifies the minification for all `chunk` entries.
+
+```ts
+// bundler.config.ts
+
+import { defineConfig } from '@hypernym/bundler'
+
+export default defineConfig({
+  minify: true,
+})
+```
+
+It can also be set per entry.
+
+```ts
+export default defineConfig({
+  entries: [
+    {
+      input: './src/index.ts',
+      minify: true,
+    },
+  ],
+})
+```
+
 ## Hooks
 
 List of lifecycle hooks that are called at various phases:
@@ -466,16 +488,6 @@ export default defineConfig({
     },
   ],
 })
-```
-
-## CLI
-
-### Custom Config
-
-Set a custom config path via the CLI command:
-
-```sh
-npx hyperbundler --config hyper.config.ts
 ```
 
 ## Community

--- a/src/bin/build.ts
+++ b/src/bin/build.ts
@@ -2,7 +2,7 @@ import { resolve, parse } from 'node:path'
 import { stat } from 'node:fs/promises'
 import { dim } from '@hypernym/colors'
 import { write, copy, readdir } from '@hypernym/utils/fs'
-import { isObject, isString } from '@hypernym/utils'
+import { isObject, isString, isUndefined } from '@hypernym/utils'
 import { rollup } from 'rollup'
 import { getLogFilter } from 'rollup/getLogFilter'
 import replacePlugin from '@rollup/plugin-replace'
@@ -151,7 +151,14 @@ export async function build(
           externals: entry.externals || options.externals,
           format: entry.format || _format,
           transformers: entry.transformers,
-          defaultPlugins: [esbuildPlugin(entry.transformers?.esbuild)],
+          defaultPlugins: [
+            esbuildPlugin({
+              minify: !isUndefined(entry.minify)
+                ? entry.minify
+                : options.minify,
+              ...entry.transformers?.esbuild,
+            }),
+          ],
           plugins: entry.plugins,
           banner: entry.banner,
           footer: entry.footer,

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,21 @@ export const externals: RegExp[] = [
   /^rollup/,
 ]
 
+/**
+ * `Hyperbundler` automatically detects custom configuration from the project root that can override or extend the build behavior.
+ *
+ * Configuration file also accepts `.js`, `.mjs`, `.ts`, `.mts` formats.
+ *
+ * @example
+ *
+ * ```ts
+ * import { defineConfig } from '@hypernym/bundler'
+ *
+ * export default defineConfig({
+ *   // ...
+ * })
+ * ```
+ */
 export function defineConfig(options: Options): Options {
   return options
 }

--- a/src/types/entries.ts
+++ b/src/types/entries.ts
@@ -110,6 +110,12 @@ export interface EntryChunk extends EntryBase {
    * Intended for `umd/iife` formats.
    */
   extend?: OutputOptions['extend']
+  /**
+   * Minifies the generated code if enabled.
+   *
+   * @default undefined
+   */
+  minify?: boolean
   declaration?: never
   copy?: never
   template?: never
@@ -143,6 +149,7 @@ export interface EntryDeclaration extends EntryBase {
   name?: never
   globals?: never
   extend?: never
+  minify?: never
 }
 
 export interface CopyOptions {
@@ -200,6 +207,7 @@ export interface EntryCopy {
   name?: never
   globals?: never
   extend?: never
+  minify?: never
 }
 
 export interface EntryTemplate {
@@ -232,6 +240,7 @@ export interface EntryTemplate {
   name?: never
   globals?: never
   extend?: never
+  minify?: never
 }
 
 export type EntryOptions =

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -105,4 +105,31 @@ export interface Options {
    * @default undefined
    */
   alias?: Alias[]
+  /**
+   * Specifies the minification for all `chunk` entries.
+   *
+   * @example
+   *
+   * ```ts
+   * export default defineConfig({
+   *   minify: true,
+   * })
+   * ```
+   *
+   * It can also be set per entry.
+   *
+   * ```ts
+   * export default defineConfig({
+   *   entries: [
+   *     {
+   *       input: './src/index.ts',
+   *       minify: true,
+   *     },
+   *   ],
+   * })
+   * ```
+   *
+   * @default undefined
+   */
+  minify?: boolean
 }


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Documentation

## Request Description

Adds new `minify` options.

### minify

- Type: `boolean`
- Default: `undefined`

Specifies the minification for all `chunk` entries.

```ts
// bundler.config.ts

import { defineConfig } from '@hypernym/bundler'

export default defineConfig({
  minify: true,
})
```

It can also be set per entry.

```ts
export default defineConfig({
  entries: [
    {
      input: './src/index.ts',
      minify: true,
    },
  ],
})
```