### PR TITLE
feat: update bundle formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import { defineConfig } from '@hypernym/bundler'
 export default defineConfig({
   entries: [
     { input: './src/index.ts' },
-    { declaration: './src/types/index.ts' },
+    { dts: './src/types/index.ts' },
     {
       input: './src/utils/index.ts',
       output: './dist/utils/utils.min.mjs',
@@ -99,11 +99,34 @@ Set a custom config path via the CLI command:
 npx hyperbundler --config hyper.config.ts
 ```
 
+## Formats
+
+During transformation, file formats are automatically resolved and in most cases there is no need for additional configuration.
+
+`Hyperbundler` module environment for generated files defaults to `esm`, which means the outputs will have a `.mjs` extension unless otherwise specified. For TypeScript declarations, the appropriate extension will be `.d.mts`.
+
+Formats can also be explicitly specified for each entry, if necessary.
+
+### Inputs
+
+Default transformation behaviour for all `chunk` entries:
+
+- `./srcDir/file.js` resolves to `./outDir/file.mjs`
+- `./srcDir/file.mjs` resolves to `./outDir/file.mjs`
+- `./srcDir/file.cjs` resolves to `./outDir/file.cjs`
+- `./srcDir/file.ts` resolves to `./outDir/file.mjs`
+- `./srcDir/file.mts` resolves to `./outDir/file.mjs`
+- `./srcDir/file.cts` resolves to `./outDir/file.cjs`
+
+### Declarations
+
+Default transformation behaviour for all `dts` entries:
+
+- `./srcDir/file.ts` resolves to `./outDir/file.d.mts`
+
 ## Options
 
-All options are documented with descriptions and examples so auto-completion will be offered as you type.
-
-Simply hover over the property and see what it does in the `quickinfo`.
+All options are documented with descriptions and examples so auto-completion will be offered as you type. Simply hover over the property and see what it does in the `quickinfo`.
 
 ### entries
 
@@ -121,7 +144,7 @@ import { defineConfig } from '@hypernym/bundler'
 export default defineConfig({
   entries: [
     { input: './src/index.ts' }, // => './dist/index.mjs'
-    { declaration: './src/types.ts' }, // => './dist/types.d.ts'
+    { dts: './src/types.ts' }, // => './dist/types.d.mts'
     // ...
   ],
 })
@@ -140,9 +163,7 @@ import { defineConfig } from '@hypernym/bundler'
 
 export default defineConfig({
   entries: [
-    {
-      input: './src/index.ts', // => './dist/index.mjs'
-    },
+    { input: './src/index.ts' }, // => './dist/index.mjs'
   ],
 })
 ```
@@ -160,9 +181,19 @@ import { defineConfig } from '@hypernym/bundler'
 
 export default defineConfig({
   entries: [
-    {
-      { declaration: './src/types.ts' }, // => './dist/types.d.ts'
-    },
+    { declaration: './src/types.ts' }, // => './dist/types.d.mts'
+  ],
+})
+```
+
+Also, it is possible to use `dts` alias.
+
+```ts
+import { defineConfig } from '@hypernym/bundler'
+
+export default defineConfig({
+  entries: [
+    { dts: './src/types.ts' }, // => './dist/types.d.mts'
   ],
 })
 ```
@@ -373,7 +404,7 @@ export default defineConfig({
 
 ### build:entry:start
 
-- Type: `(options: BuildEntryOptions, stats: BuildStats) => void | Promise<void>`
+- Type: `(entry: BuildEntryOptions, stats: BuildEntryStats) => void | Promise<void>`
 - Default: `undefined`
 
 Called on each entry just before the build process.
@@ -388,12 +419,12 @@ import { plugin1, plugin2 } from './src/utils/plugins.js'
 
 export default defineConfig({
   hooks: {
-    'build:entry:start': async (options, stats) => {
+    'build:entry:start': async (entry, stats) => {
       // adds custom plugins for a specific entry only
-      if (options.input?.includes('./src/index.ts')) {
-        options.defaultPlugins = [
+      if (entry.input?.includes('./src/index.ts')) {
+        entry.defaultPlugins = [
           plugin1(), // adds a custom plugin before the default bundler plugins
-          ...options.defaultPlugins, // list of default bundler plugins
+          ...entry.defaultPlugins, // list of default bundler plugins
           plugin2(), // adds a custom plugin after the default bundler plugins
         ]
       }
@@ -404,7 +435,7 @@ export default defineConfig({
 
 ### build:entry:end
 
-- Type: `(options: BuildEntryOptions, stats: BuildStats) => void | Promise<void>`
+- Type: `(entry: BuildEntryOptions, stats: BuildEntryStats) => void | Promise<void>`
 - Default: `undefined`
 
 Called on each entry right after the build process is completed.
@@ -416,7 +447,7 @@ import { defineConfig } from '@hypernym/bundler'
 
 export default defineConfig({
   hooks: {
-    'build:entry:end': async (options, stats) => {
+    'build:entry:end': async (entry, stats) => {
       // ...
     },
   },

--- a/bundler.config.ts
+++ b/bundler.config.ts
@@ -4,12 +4,19 @@ import { version } from './package.json'
 export default defineConfig({
   entries: [
     { input: './src/index.ts' },
-    { declaration: './src/types/index.ts' },
+    { dts: './src/types/index.ts' },
+    {
+      input: './src/index.ts',
+      output: './dist/index.cjs',
+    },
+    {
+      dts: './src/types/index.ts',
+      output: './dist/types/index.d.cts',
+    },
     {
       input: './src/bin/index.ts',
       transformers: {
         replace: {
-          preventAssignment: true,
           __version__: version,
         },
       },

--- a/src/types/build.ts
+++ b/src/types/build.ts
@@ -1,10 +1,37 @@
 import type { Plugin, LogLevel, RollupLog } from 'rollup'
-import type { EntryBase } from './entries'
+import type { EntryBase, EntryChunk, EntryDeclaration } from './entries'
 import type { TransformersChunk, TransformersDeclaration } from './transformers'
 
 export interface BuildLogs {
   level: LogLevel
   log: RollupLog
+}
+
+export interface BuildEntryStats {
+  /**
+   * The root path of the project.
+   */
+  cwd: string
+  /**
+   * Module output path.
+   */
+  path: string
+  /**
+   * Module size.
+   */
+  size: number
+  /**
+   * Build time of individual module.
+   */
+  buildTime: number
+  /**
+   * Module format.
+   */
+  format: string
+  /**
+   * List of warnings from build plugins.
+   */
+  logs: BuildLogs[]
 }
 
 export interface BuildStats {
@@ -23,31 +50,28 @@ export interface BuildStats {
   /**
    * List of generated bundle modules.
    */
-  files: {
-    /**
-     * Module output path.
-     */
-    path: string
-    /**
-     * Module size.
-     */
-    size: number
-    /**
-     * Build time of individual module.
-     */
-    buildTime: number
-    /**
-     * Module format.
-     */
-    format: string
-    /**
-     * List of warnings from build plugins.
-     */
-    logs: BuildLogs[]
-  }[]
+  files: BuildEntryStats[]
 }
 
-export interface BuildEntryOptions extends EntryBase {
+type PickEntryChunkOptions =
+  | 'input'
+  | 'name'
+  | 'globals'
+  | 'extend'
+  | 'minify'
+  | 'transformers'
+type PickEntryDtsOptions = 'declaration' | 'dts' | 'transformers'
+
+export interface BuildEntryOptions
+  extends EntryBase,
+    Pick<EntryChunk, PickEntryChunkOptions>,
+    Pick<EntryDeclaration, PickEntryDtsOptions> {
+  /**
+   * Specifies the path of the transformed file.
+   *
+   * @default undefined
+   */
+  output?: string
   /**
    * Specifies options for default plugins.
    *

--- a/src/types/entries.ts
+++ b/src/types/entries.ts
@@ -66,10 +66,33 @@ export interface EntryBase {
 export interface EntryChunk extends EntryBase {
   /**
    * Specifies the path of the build source.
+   *
+   * @example
+   *
+   * ```ts
+   * export default defineConfig({
+   *   entries: [
+   *     { input: './src/index.ts' }, // => './dist/index.mjs'
+   *   ]
+   * })
+   * ```
    */
   input?: string
   /**
    * Specifies the path of the transformed file.
+   *
+   * @example
+   *
+   * ```ts
+   * export default defineConfig({
+   *   entries: [
+   *     {
+   *       input: './src/index.ts',
+   *       output: './out/index.js', // => './out/index.js'
+   *     },
+   *   ]
+   * })
+   * ```
    *
    * @default undefined
    */
@@ -117,6 +140,7 @@ export interface EntryChunk extends EntryBase {
    */
   minify?: boolean
   declaration?: never
+  dts?: never
   copy?: never
   template?: never
 }
@@ -124,10 +148,49 @@ export interface EntryChunk extends EntryBase {
 export interface EntryDeclaration extends EntryBase {
   /**
    * Specifies the path of the TypeScript `declaration` build source.
+   *
+   * @example
+   *
+   * ```ts
+   * export default defineConfig({
+   *   entries: [
+   *     { dts: './src/types.ts' }, // => './dist/types.d.mts'
+   *   ]
+   * })
+   * ```
+   */
+  dts?: string
+  /**
+   * Specifies the path of the TypeScript `declaration` build source.
+   *
+   * Also, it is possible to use `dts` alias.
+   *
+   * @example
+   *
+   * ```ts
+   * export default defineConfig({
+   *   entries: [
+   *     { declaration: './src/types.ts' }, // => './dist/types.d.mts'
+   *   ]
+   * })
+   * ```
    */
   declaration?: string
   /**
    * Specifies the path of the TypeScript  transformed `declaration` file.
+   *
+   * @example
+   *
+   * ```ts
+   * export default defineConfig({
+   *   entries: [
+   *     {
+   *       dts: './src/types.ts',
+   *       output: './out/types.d.ts', // => './out/types.d.ts'
+   *     },
+   *   ]
+   * })
+   * ```
    *
    * @default undefined
    */
@@ -203,6 +266,7 @@ export interface EntryCopy {
   copy?: CopyOptions
   input?: never
   declaration?: never
+  dts?: never
   template?: never
   name?: never
   globals?: never
@@ -236,6 +300,7 @@ export interface EntryTemplate {
   output: string
   input?: never
   declaration?: never
+  dts?: never
   copy?: never
   name?: never
   globals?: never

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,5 +1,5 @@
 import type { Options } from './options'
-import type { BuildStats, BuildEntryOptions } from './build'
+import type { BuildEntryStats, BuildStats, BuildEntryOptions } from './build'
 
 export interface HooksOptions {
   /**
@@ -48,7 +48,7 @@ export interface HooksOptions {
    * ```ts
    * export default defineConfig({
    *   hooks: {
-   *     'build:entry:start': async (options, stats) => {
+   *     'build:entry:start': async (entry, stats) => {
    *      // ...
    *     }
    *   }
@@ -58,8 +58,8 @@ export interface HooksOptions {
    * @default undefined
    */
   'build:entry:start'?: (
-    options: BuildEntryOptions,
-    stats: BuildStats,
+    entry: BuildEntryOptions,
+    stats: BuildEntryStats,
   ) => void | Promise<void>
   /**
    * Called on each entry right after the build process is completed.
@@ -69,7 +69,7 @@ export interface HooksOptions {
    * ```ts
    * export default defineConfig({
    *   hooks: {
-   *     'build:entry:end': async (options, stats) => {
+   *     'build:entry:end': async (entry, stats) => {
    *      // ...
    *     }
    *   }
@@ -79,8 +79,8 @@ export interface HooksOptions {
    * @default undefined
    */
   'build:entry:end'?: (
-    options: BuildEntryOptions,
-    stats: BuildStats,
+    entry: BuildEntryOptions,
+    stats: BuildEntryStats,
   ) => void | Promise<void>
   /**
    * Called right after building is complete.

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -14,7 +14,7 @@ export interface Options {
    * export default defineConfig({
    *   entries: [
    *     { input: './src/index.ts' }, // => './dist/index.mjs'
-   *     { declaration: './src/types.ts' }, // => './dist/types.d.ts'
+   *     { dts: './src/types.ts' }, // => './dist/types.d.mts'
    *     // ...
    *   ]
    * })

--- a/src/utils/get-longest-output.ts
+++ b/src/utils/get-longest-output.ts
@@ -8,24 +8,20 @@ export function getLongestOutput(
   const outputs: string[] = []
 
   for (const entry of entries) {
-    if ('copy' in entry && entry.copy) {
-      const out = entry.copy.output
-      outputs.push(out)
-    }
+    if (entry.copy) outputs.push(entry.copy.output)
 
-    if ('input' in entry && entry.input) {
+    if (entry.input) {
       const out = entry.output || getOutputPath(outDir, entry.input)
       outputs.push(out)
     }
 
-    if ('declaration' in entry && entry.declaration) {
-      const out = entry.output || getOutputPath(outDir, entry.declaration, true)
+    if (entry.declaration || entry.dts) {
+      const dts = entry.declaration! || entry.dts!
+      const out = entry.output || getOutputPath(outDir, dts, true)
       outputs.push(out)
     }
 
-    if ('template' in entry && entry.template) {
-      outputs.push(entry.output)
-    }
+    if (entry.template) outputs.push(entry.output)
   }
 
   return Math.max(...outputs.map((v) => v.length))

--- a/src/utils/get-output-path.ts
+++ b/src/utils/get-output-path.ts
@@ -1,20 +1,19 @@
 export function getOutputPath(
   outDir: string,
   input: string,
-  types: boolean = false,
+  dts?: boolean,
 ): string {
   const _input = input.startsWith('./') ? input.slice(2) : input
   let output = _input.replace(_input.split('/')[0], outDir)
 
-  const ts = types ? 'd.ts' : 'mjs'
-  const mts = types ? 'd.mts' : 'mjs'
-  const cts = types ? 'd.cts' : 'cjs'
+  const ext = dts ? 'd.mts' : 'mjs'
+  const cts = dts ? 'd.cts' : 'cjs'
 
-  if (output.endsWith('.ts')) output = `${output.slice(0, -2)}${ts}`
-  if (output.endsWith('.mts')) output = `${output.slice(0, -3)}${mts}`
-  if (output.endsWith('.cts')) output = `${output.slice(0, -3)}${cts}`
+  if (output.endsWith('.js')) output = `${output.slice(0, -2)}${ext}`
+  else if (output.endsWith('.ts')) output = `${output.slice(0, -2)}${ext}`
+  else if (output.endsWith('.mts')) output = `${output.slice(0, -3)}${ext}`
+  else if (output.endsWith('.cts')) output = `${output.slice(0, -3)}${cts}`
 
   if (outDir.startsWith('./') || outDir.startsWith('../')) return output
-
-  return `./${output}`
+  else return `./${output}`
 }


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Documentation
- [x] Breaking change

## Breaking Changes

Changes default file formats for generated `.js` and `.d.ts` files .

### Formats

During transformation, file formats are automatically resolved and in most cases there is no need for additional configuration.

`Hyperbundler` module environment for generated files defaults to `esm`, which means the outputs will have a `.mjs` extension unless otherwise specified. For TypeScript declarations, the appropriate extension will be `.d.mts`.

Formats can also be explicitly specified for each entry, if necessary.

### Inputs

Default transformation behaviour for all `chunk` entries:

- `./srcDir/file.js` resolves to `./outDir/file.mjs`
- `./srcDir/file.mjs` resolves to `./outDir/file.mjs`
- `./srcDir/file.cjs` resolves to `./outDir/file.cjs`
- `./srcDir/file.ts` resolves to `./outDir/file.mjs`
- `./srcDir/file.mts` resolves to `./outDir/file.mjs`
- `./srcDir/file.cts` resolves to `./outDir/file.cjs`

### Declarations

Default transformation behaviour for all `dts` entries:

- `./srcDir/file.ts` resolves to `./outDir/file.d.mts`

## Features

Adds `dts` alias for `declaration` entries.

### Entry Declaration

Builds TypeScript `declaration` files (.d.ts) for production.

```ts
// bundler.config.ts

import { defineConfig } from '@hypernym/bundler'

export default defineConfig({
  entries: [
    { declaration: './src/types.ts' }, // => './dist/types.d.mts'
  ],
})
```

Also, it is possible to use `dts` alias.

```ts
import { defineConfig } from '@hypernym/bundler'

export default defineConfig({
  entries: [
    { dts: './src/types.ts' }, // => './dist/types.d.mts'
  ],
})
```

## Other Changes

- Improves `types`
- Improves `docs`